### PR TITLE
Return proper response when using stream output

### DIFF
--- a/lib/http-get.js
+++ b/lib/http-get.js
@@ -204,10 +204,15 @@ var get = function (options, file, cb, reqId) {
 					
 					if (options.stream === true) {
 						stream.pause();
-						cb(null, {
+						ret = {
+							code: res.statusCode,
 							headers: res.headers,
 							stream: stream
-						});
+						};
+						if (reqId > 0) {
+							ret.url = options.url;
+						}
+						cb(null, ret);
 						
 						return;
 					}

--- a/tests/request-stream.js
+++ b/tests/request-stream.js
@@ -32,6 +32,7 @@ server.listen(common.options.port, common.options.host, function () {
 		var count = 0;
 		
 		assert.ifError(err);
+		assert.strictEqual(res.code, 200);
 		assert.deepEqual(res.headers['content-type'], 'application/octet-stream');
 		assert.deepEqual(res.headers['content-length'], 10485760);
 		


### PR DESCRIPTION
The 'code', and more importantly, the 'url' properties are not included in the response which I fixed with this patch.
