### PR TITLE
Add ability to manually specify the used agent

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -183,6 +183,10 @@ var processInput = function (options) {
 		}
 	}
 	
+	if (options.agent) {
+		opt.agent = options.agent;
+	}
+	
 	if (url.protocol === 'https:') {
 		if (options.noSslVerifier !== true) {
 			opt.rejectUnauthorized = true;
@@ -196,7 +200,9 @@ var processInput = function (options) {
 			opt.ca = opt.ca.concat(options.ca);
 		}
 		
-		opt.agent = new client.Agent(opt);
+		if(!opt.agent) {
+			opt.agent = new client.Agent(opt);
+		}
 		
 		if ( ! semver.satisfies(process.version, '>=0.8.5')) {
 			console.error('Warning: the proper HTTPS functionality of http-get requires at least node.js v0.8.5. You are using %s, therefore a deprecated version. Consider an upgrade as this functionality is going to be turned off for older node versions in the future versions of this library.', process.version);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "http-get",
-	"version": "0.5.9",
+	"version": "0.5.10",
 	"main": "./lib/http-get.js",
 	"description": "Simple to use node.js HTTP / HTTPS client for downloading remote files. Supports transparent gzip / deflate decoding.",
 	"dependencies": {


### PR DESCRIPTION
Hi,

I had a problem with thousands of waiting sockets in TIME_WAIT state. The underlying problem is described here: https://github.com/joyent/node/issues/1958

One possible solution is to use a custom agent like 
https://github.com/TBEDP/agentkeepalive

The patch allows the usage of such an agent with http-get.

Regards
Stefan
