### PR TITLE
Fix documentation typo: "turn of listeners"

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,7 @@ exports.createHttpClient = function(options) {
  * HTTP GET method wrapper
  *
  * @param {module:request~options} options The options Object taken by the {@link Request} constructor, filtered by {@link module:tools.shortHand}. options.method = 'GET' and it can not be overridden
- * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns of the data listeners
+ * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns off the data listeners
  * @param {module:main~callback} callback Completion callback
  *
  * @example
@@ -187,7 +187,7 @@ exports.head = function(options, callback) {
  * HTTP DELETE method wrapper
  *
  * @param {module:request~options} options The options Object taken by the {@link Request} constructor, filtered by {@link module:tools.shortHand}. options.method = 'DELETE' and it can not be overridden
- * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns of the data listeners
+ * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns off the data listeners
  * @param {module:main~callback} callback Completion callback
  *
  * @example
@@ -222,7 +222,7 @@ exports.delete = function(options, file, callback) {
  * HTTP POST method wrapper
  *
  * @param {module:request~options} options The options Object taken by the {@link Request} constructor, filtered by {@link module:tools.shortHand}. options.method = 'POST' and it can not be overridden
- * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns of the data listeners
+ * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns off the data listeners
  * @param {module:main~callback} callback Completion callback
  *
  * @example
@@ -324,7 +324,7 @@ exports.post = function(options, file, callback) {
  * HTTP PUT method wrapper
  *
  * @param {module:request~options} options The options Object taken by the {@link Request} constructor, filtered by {@link module:tools.shortHand}. options.method = 'PUT' and it can not be overridden
- * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns of the data listeners
+ * @param {String|null} file Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns off the data listeners
  * @param {module:main~callback} callback Completion callback
  *
  * @example


### PR DESCRIPTION
In specifying the optional `file` parameter for the DELETE, GET, POST, and PUT methods, the documentation reads:

> Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns of the data listeners

I think it should read (emphasis mine): 

> Optional; specify a filesystem path to save the response body as file instead of Buffer. Passing null turns **off** the data listeners
