### PR TITLE
indented to communicate CL install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# http-request [![build status](https://secure.travis-ci.org/SaltwaterC/http-request.png?branch=master)](https://travis-ci.org/SaltwaterC/http-request) [![NPM version](https://badge.fury.io/js/http-request.png)](http://badge.fury.io/js/http-request)
+# http-request [![build status](https://secure.travis-ci.org/SaltwaterC/http-request.png?branch=master)](https://travis-ci.org/SaltwaterC/http-request)Â [![NPM version](https://badge.fury.io/js/http-request.png)](http://badge.fury.io/js/http-request)
 
 General purpose HTTP / HTTPS client for node.js. Supports transparent gzip / deflate decoding. Successor of http-get.
 
 ## Installation
 
-> npm install http-request
+    npm install http-request
 
 ## Reference
 


### PR DESCRIPTION
this helps to visually communicate the style standard of installing with the npm command in the command line, especially to newer users.

Before
![screen shot 2015-06-03 at 12 23 26 pm](https://cloud.githubusercontent.com/assets/7812178/7969519/3cb64a18-09ec-11e5-9b6c-dce886e05290.png)

After
![screen shot 2015-06-03 at 12 31 15 pm](https://cloud.githubusercontent.com/assets/7812178/7969554/77333cbe-09ec-11e5-90f5-f26d0c628999.png)
