### PR TITLE
Don't abort request, if it returned an error status but is otherwise fine

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -138,6 +138,7 @@ Request.prototype.saveBuffer = function(callback) {
 		}
 
 		if (err) {
+			self.request.abort();
 			self.error(err, callback);
 		}
 	});
@@ -188,6 +189,7 @@ Request.prototype.saveFile = function(file, callback) {
 	var ws = fs.createWriteStream(file);
 
 	ws.on('error', function(err) {
+		self.request.abort();
 		self.error(err, callback);
 	});
 
@@ -425,6 +427,7 @@ Request.prototype.send = function(callback) {
 
 					if (size > 1048576) {
 						err.largeDocument = true;
+						self.request.abort();
 						self.error(err, callback);
 					}
 				});
@@ -437,6 +440,7 @@ Request.prototype.send = function(callback) {
 				stream.on('error', function(zErr) {
 					err.noDocument = true;
 					err.message = zErr.message;
+					self.request.abort();
 					self.error(err, callback);
 				});
 
@@ -445,6 +449,7 @@ Request.prototype.send = function(callback) {
 
 				// catch all error handler
 			default:
+				self.request.abort();
 				self.error(tools.formattedError('HTTP Error: %d', response.statusCode), callback);
 				self.response.resume();
 				break;
@@ -537,9 +542,6 @@ Request.prototype.error = function(error, callback) {
 
 	if (!this.states.error && !this.states.finish) {
 		this.states.error = true;
-		if (this.request) {
-			this.request.abort();
-		}
 
 		if (!error.code && this.response) {
 			error.code = this.response.statusCode;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 		"node": ">= 0.8.5"
 	},
 	"dependencies": {
-		"form-data": ">= 0.1.2",
-		"mmmagic": ">= 0.3.4"
+		"form-data": "~0.1.2",
+		"mmmagic": "~0.3.4"
 	},
 	"devDependencies": {
 		"mocha": ">= 1.8.2",


### PR DESCRIPTION
Hi I stumbled upon the following problem:
I use this module inside a cache seeder which sends lots of GET requests to a cache. In some cases the cache correctly answers with several thousands of 404s. 
As http-request always calls request.abort() in an error case (even though there wasn't really an error, just the response code is 404), nodejs closes the socket and doesn't use it with keepAlive connections. That resulted in my server running out of sockets/ports.

The patch isn't really nice. The only place where I really wanted to prevent request.abort() is in request.js line 432:

``` javascript
stream.on('end', function() {
    err.document = Buffer.concat(buf, size);
    self.error(err, callback); //request mustn't abort here
});
```

So any advice on a better solution is greatly appreciated.

Cheers Stefan
